### PR TITLE
feat: forgot password

### DIFF
--- a/emails/reset-password-email.tsx
+++ b/emails/reset-password-email.tsx
@@ -6,6 +6,7 @@ import {
   Heading,
   Hr,
   Html,
+  Link,
   Preview,
   Section,
   Tailwind,
@@ -13,26 +14,24 @@ import {
 } from "@react-email/components"
 import { Support } from "./components/support"
 
-type OTPEmailProps = {
-  otp?: string
+type ResetPasswordEmailProps = {
+  url?: string
   userName?: string
-  expiryMinutes?: number
 }
 
-export default function OTPEmail({
-  otp = "123456",
-  userName = "User",
-  expiryMinutes = 15
-}: OTPEmailProps) {
+export default function ResetPasswordEmail({
+  url = "https://tasklytic.fesyse.site",
+  userName = "User"
+}: ResetPasswordEmailProps) {
   return (
     <Tailwind config={tailwindConfig}>
       <Html>
         <Head />
-        <Preview>Your verification code</Preview>
+        <Preview>Reset your password - Tasklytic</Preview>
         <Body className="bg-background mx-auto my-0 font-sans">
           <Container className="bg-card mx-auto my-10 max-w-md rounded-xl border border-solid border-[#eaeaea] p-8">
             <Heading className="text-foreground mb-6 text-center text-2xl font-bold">
-              Verification Code
+              Reset your password
             </Heading>
 
             <Text className="text-muted-foreground mb-6 text-base">
@@ -40,21 +39,27 @@ export default function OTPEmail({
             </Text>
 
             <Text className="text-muted-foreground mb-4 text-base">
-              Please use the verification code below to complete your action:
+              Please click the link below to reset your password:
             </Text>
 
             <Section className="mb-6 text-center">
-              <div className="bg-secondary mx-auto rounded-lg px-2 py-6 text-center">
-                <Text className="text-primary m-0 font-mono text-3xl font-bold tracking-widest">
-                  {otp}
-                </Text>
-              </div>
+              <Link
+                href={url}
+                className="bg-primary text-primary-foreground hover:bg-primary/90 inline-flex rounded-md px-4 py-3 text-center text-sm shadow-xs"
+              >
+                Click here to reset your password
+              </Link>
             </Section>
 
-            <Text className="text-muted-foreground mb-6 text-sm">
-              This code will expire in {expiryMinutes} minutes. If you didn't
-              request this code, you can safely ignore this email.
-            </Text>
+            <Section className="mb-6 text-center text-sm">
+              <Text className="text-muted-foreground mb-0">
+                This link will expire in 15 minutes.
+              </Text>
+              <Text className="text-muted-foreground mt-2">
+                If you didn't request this password reset, you can safely ignore
+                this email. Your account is secure.
+              </Text>
+            </Section>
 
             <Hr className="my-6 border border-solid border-[#eaeaea]" />
 

--- a/emails/verify-email.tsx
+++ b/emails/verify-email.tsx
@@ -27,7 +27,7 @@ export default function VerifyEmail({
     <Tailwind config={tailwindConfig}>
       <Html>
         <Head />
-        <Preview>Sign Up - Verify your email</Preview>
+        <Preview>Verify your email | Sign Up - Tasklytic</Preview>
         <Body className="bg-background mx-auto my-0 font-sans">
           <Container className="bg-card mx-auto my-10 max-w-md rounded-xl border border-solid border-[#eaeaea] p-8">
             <Heading className="text-foreground mb-6 text-center text-2xl font-bold">

--- a/src/app/auth/forgot-password/page.tsx
+++ b/src/app/auth/forgot-password/page.tsx
@@ -1,7 +1,14 @@
+import { AuthHeader } from "@/components/auth/auth-header"
+import { ForgotPasswordForm } from "@/components/auth/forgot-password-form"
+
 export default function ForgotPasswordPage() {
   return (
-    <div>
-      <h1>Forgot Password</h1>
-    </div>
+    <>
+      <AuthHeader
+        title="Forgot password"
+        description="Please fill out form below to recover your account"
+      />
+      <ForgotPasswordForm />
+    </>
   )
 }

--- a/src/app/auth/forgot-password/proceed/loading.tsx
+++ b/src/app/auth/forgot-password/proceed/loading.tsx
@@ -1,0 +1,24 @@
+import { AuthHeader } from "@/components/auth/auth-header"
+import { Skeleton } from "@/components/ui/skeleton"
+import { Loader2 } from "lucide-react"
+
+export default function ForgotPasswordProceedLoading() {
+  return (
+    <>
+      <AuthHeader
+        title="Reset your password"
+        description="Loading your reset request..."
+      />
+      <div className="mt-6 flex flex-col items-center justify-center space-y-4">
+        <div className="flex h-12 w-full items-center justify-center">
+          <Loader2 className="text-primary h-8 w-8 animate-spin" />
+        </div>
+        <div className="w-full space-y-4">
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="mt-2 h-10 w-full" />
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/app/auth/forgot-password/proceed/page.tsx
+++ b/src/app/auth/forgot-password/proceed/page.tsx
@@ -1,0 +1,221 @@
+"use client"
+
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useRouter, useSearchParams } from "next/navigation"
+import { useEffect, useState } from "react"
+import { useForm } from "react-hook-form"
+import { z } from "zod"
+
+import { AuthHeader } from "@/components/auth/auth-header"
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Button } from "@/components/ui/button"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage
+} from "@/components/ui/form"
+import { PasswordInput } from "@/components/ui/password-input"
+import { authClient } from "@/lib/auth-client"
+import { AlertCircle, CheckCircle, Loader2 } from "lucide-react"
+
+const resetPasswordSchema = z
+  .object({
+    newPassword: z.string().min(8, {
+      message: "Password must be at least 8 characters long"
+    }),
+    confirmPassword: z.string().min(8)
+  })
+  .refine((data) => data.newPassword === data.confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"]
+  })
+
+type ResetPasswordSchema = z.infer<typeof resetPasswordSchema>
+
+export default function ForgotPasswordProceedPage() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const [status, setStatus] = useState<
+    "idle" | "loading" | "success" | "error"
+  >("idle")
+  const [errorMessage, setErrorMessage] = useState<string>("")
+  const token = searchParams.get("token")
+
+  const form = useForm<ResetPasswordSchema>({
+    resolver: zodResolver(resetPasswordSchema),
+    defaultValues: {
+      newPassword: "",
+      confirmPassword: ""
+    }
+  })
+
+  const handleNoTokenError = () => {
+    setStatus("error")
+    setErrorMessage(
+      "Reset token is missing. Please try the password reset process again."
+    )
+  }
+
+  useEffect(() => {
+    if (!token) {
+      handleNoTokenError()
+    }
+  }, [token])
+
+  const onSubmit = async (data: ResetPasswordSchema) => {
+    if (!token) {
+      handleNoTokenError()
+      return
+    }
+
+    setStatus("loading")
+
+    try {
+      const result = await authClient.resetPassword({
+        newPassword: data.newPassword,
+        token
+      })
+
+      if (result.error) {
+        setStatus("error")
+        setErrorMessage(
+          result.error.message || "Failed to reset password. Please try again."
+        )
+        return
+      }
+
+      setStatus("success")
+
+      // Redirect after a short delay to show success message
+      setTimeout(() => {
+        router.push("/auth/sign-in")
+      }, 3500)
+    } catch (error) {
+      setStatus("error")
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : "An unexpected error occurred. Please try again."
+      )
+    }
+  }
+
+  if (status === "success") {
+    return (
+      <>
+        <AuthHeader
+          title="Password Reset Successful"
+          description="Your password has been reset successfully."
+        />
+        <Alert
+          variant="default"
+          className="mt-6 border-green-200 bg-green-50 text-green-800"
+        >
+          <CheckCircle className="h-5 w-5 text-green-600" />
+          <AlertTitle>Success!</AlertTitle>
+          <AlertDescription>
+            Your password has been reset. You will be redirected to the sign-in
+            page shortly.
+          </AlertDescription>
+        </Alert>
+        <Button
+          className="mt-6 w-full"
+          onClick={() => router.push("/auth/sign-in")}
+        >
+          Go to Sign In
+        </Button>
+      </>
+    )
+  }
+
+  if (status === "error" && !token) {
+    return (
+      <>
+        <AuthHeader
+          title="Invalid Password Reset"
+          description="We couldn't process your password reset request."
+        />
+        <Alert variant="destructive" className="mt-6">
+          <AlertCircle className="h-5 w-5" />
+          <AlertTitle>Error</AlertTitle>
+          <AlertDescription>{errorMessage}</AlertDescription>
+        </Alert>
+        <Button
+          className="mt-6 w-full"
+          onClick={() => router.push("/auth/forgot-password")}
+        >
+          Try Again
+        </Button>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <AuthHeader
+        title="Reset your password"
+        description="Enter your new password below"
+      />
+      {status === "error" && (
+        <Alert variant="destructive" className="mb-6">
+          <AlertCircle className="h-5 w-5" />
+          <AlertTitle>Error</AlertTitle>
+          <AlertDescription>{errorMessage}</AlertDescription>
+        </Alert>
+      )}
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+          <FormField
+            control={form.control}
+            name="newPassword"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>New Password</FormLabel>
+                <FormControl>
+                  <PasswordInput
+                    placeholder="Enter your new password"
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="confirmPassword"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Confirm Password</FormLabel>
+                <FormControl>
+                  <PasswordInput
+                    placeholder="Confirm your new password"
+                    {...field}
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <Button
+            className="w-full"
+            type="submit"
+            disabled={status === "loading"}
+          >
+            {status === "loading" ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Resetting password...
+              </>
+            ) : (
+              "Reset Password"
+            )}
+          </Button>
+        </form>
+      </Form>
+    </>
+  )
+}

--- a/src/app/auth/sign-in/page.tsx
+++ b/src/app/auth/sign-in/page.tsx
@@ -1,14 +1,13 @@
 import { AuthForm } from "@/components/auth/auth-form"
+import { AuthHeader } from "@/components/auth/auth-header"
 
 export default async function SignInPage() {
   return (
     <>
-      <div className="mb-4 flex flex-col items-center gap-2 text-center">
-        <h1 className="text-2xl font-bold">Sign in</h1>
-        <p className="text-muted-foreground text-sm text-balance">
-          Enter your email below to sign in to your account
-        </p>
-      </div>
+      <AuthHeader
+        title="Sign in"
+        description="Enter your email below to sign in to your account"
+      />
       <AuthForm type="sign-in" />
     </>
   )

--- a/src/app/auth/sign-up/page.tsx
+++ b/src/app/auth/sign-up/page.tsx
@@ -1,14 +1,13 @@
 import { AuthForm } from "@/components/auth/auth-form"
+import { AuthHeader } from "@/components/auth/auth-header"
 
 export default async function SignUpPage() {
   return (
     <>
-      <div className="mb-4 flex flex-col items-center gap-2 text-center">
-        <h1 className="text-2xl font-bold">Sign up</h1>
-        <p className="text-muted-foreground text-sm text-balance">
-          Enter your email below to create new account
-        </p>
-      </div>
+      <AuthHeader
+        title="Sign up"
+        description="Enter your email below to create new account"
+      />
       <AuthForm type="sign-up" />
     </>
   )

--- a/src/app/auth/verify-email/page.tsx
+++ b/src/app/auth/verify-email/page.tsx
@@ -1,5 +1,4 @@
-import { Button } from "@/components/ui/button"
-import Link from "next/link"
+import { GoToInboxButton } from "@/components/go-to-inbox-button"
 import { notFound } from "next/navigation"
 
 type VerifyEmailProps = {
@@ -24,9 +23,7 @@ export default async function VerifyEmail({ searchParams }: VerifyEmailProps) {
           link to verify your account.
         </p>
 
-        <Button asChild variant="outline" className="mt-3">
-          <Link href={`mailto:${email}`}>Go to inbox</Link>
-        </Button>
+        <GoToInboxButton variant="outline" className="mt-3" email={email} />
       </div>
     </div>
   )

--- a/src/components/auth/auth-form.tsx
+++ b/src/components/auth/auth-form.tsx
@@ -84,14 +84,21 @@ export function AuthForm({
       setIsLoading(false)
     } else {
       setIsLoading(true)
-      await authClient.signUp.email({
+      const { data: newUser, error } = await authClient.signUp.email({
         name: data.name,
         email: data.email,
         password: data.password,
         callbackURL: "/dashboard"
       })
 
-      router.push(`/auth/verify-email?email=${data.email}`)
+      if (error) {
+        toast.error(error.message)
+      } else {
+        if (!newUser?.user.emailVerified) {
+          router.push(`/auth/verify-email?email=${data.email}`)
+        }
+      }
+
       setIsLoading(false)
     }
   }

--- a/src/components/auth/auth-header.tsx
+++ b/src/components/auth/auth-header.tsx
@@ -1,0 +1,30 @@
+import { cn } from "@/lib/utils"
+
+type AuthHeaderProps = React.ComponentProps<"button"> & {
+  title: string
+  description?: string
+}
+
+export const AuthHeader: React.FC<AuthHeaderProps> = ({
+  title,
+  description,
+  className,
+  ...props
+}) => {
+  return (
+    <div
+      className={cn(
+        "mb-4 flex flex-col items-center gap-2 text-center",
+        className
+      )}
+      {...props}
+    >
+      <h1 className="text-2xl font-bold">{title}</h1>
+      {description ? (
+        <p className="text-muted-foreground text-sm text-balance">
+          {description}
+        </p>
+      ) : null}
+    </div>
+  )
+}

--- a/src/components/auth/forgot-password-form.tsx
+++ b/src/components/auth/forgot-password-form.tsx
@@ -1,0 +1,75 @@
+"use client"
+
+import { Button } from "@/components/ui/button"
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage
+} from "@/components/ui/form"
+import { Input } from "@/components/ui/input"
+import { authClient } from "@/lib/auth-client"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { useState } from "react"
+import { useForm } from "react-hook-form"
+import { toast } from "sonner"
+import { z } from "zod"
+import { GoToInboxButton } from "../go-to-inbox-button"
+
+const forgotPasswordSchema = z.object({
+  email: z.string().email()
+})
+
+type ForgotPasswordSchema = z.infer<typeof forgotPasswordSchema>
+
+export const ForgotPasswordForm = () => {
+  const form = useForm<ForgotPasswordSchema>({
+    resolver: zodResolver(forgotPasswordSchema)
+  })
+  const email = form.watch("email")
+  const [isClicked, setIsClicked] = useState(false)
+
+  const onSubmit = async (data: ForgotPasswordSchema) => {
+    setIsClicked(true)
+    const { error } = await authClient.forgetPassword({
+      email: data.email,
+      redirectTo: "/auth/forgot-password/proceed"
+    })
+
+    if (error) {
+      setIsClicked(false)
+      return toast.error(error.message)
+    }
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)}>
+        <FormField
+          control={form.control}
+          name="email"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Email</FormLabel>
+              <FormControl>
+                <Input placeholder="Enter your email" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        {!isClicked ? (
+          <Button className="mt-6 w-full">Send reset instructions</Button>
+        ) : (
+          <GoToInboxButton
+            variant="outline"
+            className="mt-6 w-full"
+            email={email}
+          />
+        )}
+      </form>
+    </Form>
+  )
+}

--- a/src/components/go-to-inbox-button.tsx
+++ b/src/components/go-to-inbox-button.tsx
@@ -1,0 +1,14 @@
+import { Button, type ButtonProps } from "@/components/ui/button"
+import Link from "next/link"
+
+type GoToInboxButtonProps = Omit<ButtonProps, "asChild"> & {
+  email: string
+}
+
+export const GoToInboxButton = ({ email, ...props }: GoToInboxButtonProps) => {
+  return (
+    <Button asChild {...props}>
+      <Link href={`mailto:${email}`}>Go to inbox</Link>
+    </Button>
+  )
+}

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,0 +1,63 @@
+import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const alertVariants = cva(
+  "relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground",
+  {
+    variants: {
+      variant: {
+        default: "bg-background text-foreground",
+        destructive:
+          "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+        warning:
+          "border-warning/50 bg-warning/10 text-warning dark:border-warning [&>svg]:text-warning",
+        success:
+          "border-success/50 bg-success/10 text-success dark:border-success [&>svg]:text-success"
+      }
+    },
+    defaultVariants: {
+      variant: "default"
+    }
+  }
+)
+
+const Alert = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+>(({ className, variant, ...props }, ref) => (
+  <div
+    ref={ref}
+    role="alert"
+    className={cn(alertVariants({ variant }), className)}
+    {...props}
+  />
+))
+Alert.displayName = "Alert"
+
+const AlertTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h5
+    ref={ref}
+    className={cn("mb-1 leading-none font-medium tracking-tight", className)}
+    {...props}
+  />
+))
+AlertTitle.displayName = "AlertTitle"
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm [&_p]:leading-relaxed", className)}
+    {...props}
+  />
+))
+AlertDescription.displayName = "AlertDescription"
+
+export { Alert, AlertDescription, AlertTitle }

--- a/src/components/ui/password-input.tsx
+++ b/src/components/ui/password-input.tsx
@@ -7,7 +7,7 @@ import { useState } from "react"
 
 export function PasswordInput({
   ...props
-}: React.ComponentProps<typeof Input>) {
+}: Omit<React.ComponentProps<typeof Input>, "type">) {
   const [showPassword, setShowPassword] = useState(false)
 
   return (

--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -1,8 +1,7 @@
 import { getBaseUrl } from "@/trpc/react"
-import { emailOTPClient } from "better-auth/client/plugins"
 import { createAuthClient } from "better-auth/react"
 
 export const authClient = createAuthClient({
   baseURL: getBaseUrl(),
-  plugins: [emailOTPClient()]
+  plugins: []
 })


### PR DESCRIPTION
Introduced forgot password auth implementation

### New pages

- `/auth/forgot-password`: sends email to reset password
- `/auth/forgot-password/proceed`: proceeds reseting password

#### Other changes

Also created reusable components for auth pages

